### PR TITLE
Utf handling on topic reread

### DIFF
--- a/yahoo.py
+++ b/yahoo.py
@@ -327,7 +327,7 @@ def process_single_topic(topicId,unretrievableTopicIds,unretrievableMessageIds,r
     if file_keep("%s.json" % (topicId,), "topic id: %d" % (topicId,)):
         # However, we need the previous and next topic, so we have to load the json.
         try:
-            with open('%s.json' % (topicId,), 'r') as f:
+            with open('%s.json' % (topicId,), 'r', encoding='utf-8') as f:
                 topic_json = json.load(f)
             gotTopic = True
         except:


### PR DESCRIPTION
When re-reading a topic from disk, when re-running on non-overwrite mode, force it to be read as utf-8 so avoid charmap issues (the saved topic is explicitly stored as utf-8).
To test - pick a group such as Organ and run twice in -t mode.
Without this fix there will be errors when reading back topics 112, 124 and 141.
Not a big problem because the code fetches again from internet when read fails but easy to fix.